### PR TITLE
build: use variable %windir% instead of hard-coded path

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 @echo off
 set SCRIPT_DIR=%~dp0
-set MSBUILD_PATH=C:\Windows\Microsoft.NET\Framework\v4.0.30319\
+set MSBUILD_PATH=%windir%\Microsoft.NET\Framework\v4.0.30319\
 set /p VERSION=<VERSION.txt
 set COMMON_INFO=%SCRIPT_DIR%\src\CommonAssemblyInfo.cs
 


### PR DESCRIPTION
Signed-off-by: Stefan Naewe stefan.naewe@gmail.com
